### PR TITLE
Rewrite w32-ime-wrap-function-to-control-ime using advice-add

### DIFF
--- a/w32-ime.el
+++ b/w32-ime.el
@@ -119,7 +119,7 @@ Even if IME state is not changed, these functiona are maybe called.")
   (when (and (ime-get-mode)
              (equal current-input-method "W32-IME"))
     (ime-force-off))
-  (prog1
+  (unwind-protect
       (apply orig-func args)
     (when (and (not (ime-get-mode))
                (equal current-input-method "W32-IME"))

--- a/w32-ime.el
+++ b/w32-ime.el
@@ -117,7 +117,7 @@ Even if IME state is not changed, these functiona are maybe called.")
 (defun w32-ime-wrap-advice-around-control-ime (orig-func &rest args)
   "IME control around calling ORIG-FUNC with ARGS."
   (when (and (ime-get-mode)
-	     (equal current-input-method "W32-IME"))
+             (equal current-input-method "W32-IME"))
     (ime-force-off))
   (let ((retval (apply orig-func args)))
     (when (and (not (ime-get-mode))

--- a/w32-ime.el
+++ b/w32-ime.el
@@ -300,4 +300,8 @@ Otherwise, turn off the IME state."
 
 (provide 'w32-ime)
 
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
 ;;; w32-ime.el ends here

--- a/w32-ime.el
+++ b/w32-ime.el
@@ -116,14 +116,16 @@ Even if IME state is not changed, these functiona are maybe called.")
 
 (defun w32-ime-wrap-advice-around-control-ime (orig-func &rest args)
   "IME control around calling ORIG-FUNC with ARGS."
-  (when (and (ime-get-mode)
-             (equal current-input-method "W32-IME"))
-    (ime-force-off))
-  (unwind-protect
-      (apply orig-func args)
-    (when (and (not (ime-get-mode))
-               (equal current-input-method "W32-IME"))
-      (ime-force-on))))
+  (if (and (ime-get-mode)
+           (equal current-input-method "W32-IME"))
+      (progn
+        (ime-force-off)
+        (unwind-protect
+            (apply orig-func args)
+          (when (and (not (ime-get-mode))
+                     (equal current-input-method "W32-IME"))
+            (ime-force-on))))
+    (apply orig-func args)))
 
 (define-obsolete-function-alias 'wrap-function-to-control-ime
   #'w32-ime-wrap-function-to-control-ime "2020")

--- a/w32-ime.el
+++ b/w32-ime.el
@@ -21,8 +21,8 @@
 ;;                   Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer:       Masamichi Hosoda <trueroad@trueroad.jp>
 ;; URL:              https://github.com/trueroad/w32-ime.el
-;; Version:          20200929
-;; Package-Requires: ((emacs "24.3"))
+;; Version:          20201005
+;; Package-Requires: ((emacs "24.4"))
 
 ;; w32-ime.el is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -114,36 +114,26 @@ Even if IME state is not changed, these functiona are maybe called.")
 (global-set-key [kanji] 'ignore)
 (global-set-key [compend] 'ignore)
 
+(defun w32-ime-wrap-advice-around-control-ime (orig-func &rest args)
+  "IME control around calling ORIG-FUNC with ARGS."
+  (when (and (ime-get-mode)
+	     (equal current-input-method "W32-IME"))
+    (ime-force-off))
+  (let ((retval (apply orig-func args)))
+    (when (and (not (ime-get-mode))
+               (equal current-input-method "W32-IME"))
+      (ime-force-on))
+    retval))
+
 (define-obsolete-function-alias 'wrap-function-to-control-ime
   #'w32-ime-wrap-function-to-control-ime "2020")
 
 (defun w32-ime-wrap-function-to-control-ime
-    (fn &optional interactive-p interactive-arg suffix)
-  "Wrap FN, and IME control is enabled when FUNCTION is called.
-If INTERACTIVE-P is non-nil, FUNCTION is handled as interactive and uses
-INTERACTIVE-ARG as its arguments.
-An original function is saved to FUNCTION-SUFFIX when suffix is string.
-If SUFFIX is nil, \"-original\" is added."
-  (let ((original-function
-         (intern (concat (symbol-name fn) (or suffix "-original")))))
-    (unless (fboundp original-function)
-      (fset original-function (symbol-function fn))
-      (fset fn
-            (list
-             'lambda '(&rest arguments)
-             (when interactive-p
-               (list 'interactive interactive-arg))
-             `(cond
-               ((and (ime-get-mode)
-                     (equal current-input-method "W32-IME"))
-                (ime-force-off)
-                (unwind-protect
-                    (apply ',original-function arguments)
-                  (when (and (not (ime-get-mode))
-                             (equal current-input-method "W32-IME"))
-                    (ime-force-on))))
-               (t
-                (apply ',original-function arguments))))))))
+    (fn &optional _interactive-p _interactive-arg _suffix)
+  "Wrap function FN, and IME control is enabled when FN is called.
+_INTERACTIVE-P, _INTERACTIVE-ARG, and _SUFFIX are dummy options for
+backward compatibility and no effect on any specification."
+  (advice-add fn :around #'w32-ime-wrap-advice-around-control-ime))
 
 (defvar w32-ime-toroku-region-yomigana nil
   "If this variable is string, toroku-region regard this value as yomigana.")

--- a/w32-ime.el
+++ b/w32-ime.el
@@ -119,11 +119,11 @@ Even if IME state is not changed, these functiona are maybe called.")
   (when (and (ime-get-mode)
              (equal current-input-method "W32-IME"))
     (ime-force-off))
-  (let ((retval (apply orig-func args)))
+  (prog1
+      (apply orig-func args)
     (when (and (not (ime-get-mode))
                (equal current-input-method "W32-IME"))
-      (ime-force-on))
-    retval))
+      (ime-force-on))))
 
 (define-obsolete-function-alias 'wrap-function-to-control-ime
   #'w32-ime-wrap-function-to-control-ime "2020")


### PR DESCRIPTION
https://github.com/melpa/melpa/pull/7163#issuecomment-703313376
でのご指摘により、 w32-ime-wrap-function-to-control-ime 関数を
`:around` advice による方法で完全に再実装した。

advice-add を使うようにしたため、
Emacs 24.4 以降が必要となる。

引数 _interactive-p, _interactive-arg, _suffix は不要となったが、
wrap-function-to-control-ime 関数との後方互換性確保のため、
ダミーとして受け取る。ダミーなので何を指定しても何の効果もない。

実現方法が変更になったため、
以前の実装に依存した使い方をしていた場合には動作しなくなる可能性がある。
（例：ラップ前後でインタラクティブ性やインタラクティブ引数を変更する、
　ラップ前のオリジナル関数を直接呼ぶ、など。）
しかし、通常はそういった使い方はしていないものと考えられる。